### PR TITLE
Added new short-hand capture model helpers

### DIFF
--- a/packages/helpers/src/__tests__/capture-model-hydration.test.ts
+++ b/packages/helpers/src/__tests__/capture-model-hydration.test.ts
@@ -1,0 +1,505 @@
+import { hydrateCaptureModel } from '../hydrate-capture-model';
+import uuid from 'uuid';
+import { CaptureModel } from '../../../types/src/capture-model';
+import { hydrateCompressedModel } from '../hydrate-compressed-model';
+import { captureModelShorthand } from '../capture-model-shorthand';
+
+jest.mock('../generate-id');
+const { generateId } = require('../generate-id');
+const GENERATED_ID = '[--------GENERATED-ID--------]';
+
+generateId.mockImplementation(() => GENERATED_ID);
+
+describe('capture model hydration', () => {
+  const simpleModel: CaptureModel['document'] = {
+    id: uuid.v4(),
+    type: 'entity',
+    label: 'My form',
+    properties: {
+      label: [
+        {
+          id: uuid.v4(),
+          label: 'The label',
+          type: 'text-field',
+          value: '',
+        },
+      ],
+      name: [
+        {
+          id: uuid.v4(),
+          label: 'Name of person',
+          type: 'text-field',
+          value: '',
+        },
+      ],
+    },
+  };
+
+  test('it can hydrate simple model', () => {
+    expect(
+      hydrateCaptureModel(simpleModel, {
+        label: 'Testing',
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "My form",
+        "properties": Object {
+          "label": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "The label",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Testing",
+            },
+          ],
+        },
+        "type": "entity",
+      }
+    `);
+  });
+
+  test('it can hydrate while keeping blank fields', () => {
+    expect(
+      hydrateCaptureModel(
+        simpleModel,
+        {
+          label: 'Testing',
+        },
+        { keepExtraFields: true }
+      )
+    ).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "My form",
+  "properties": Object {
+    "label": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "The label",
+        "selector": undefined,
+        "type": "text-field",
+        "value": "Testing",
+      },
+    ],
+    "name": Object {
+      "id": "[--------GENERATED-ID--------]",
+      "label": "Name of person",
+      "type": "text-field",
+      "value": "",
+    },
+  },
+  "type": "entity",
+}
+`);
+  });
+
+  test('it can hydrate model with multiple values', () => {
+    expect(
+      hydrateCaptureModel(simpleModel, {
+        label: ['Testing A', 'Testing B'],
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "My form",
+        "properties": Object {
+          "label": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "The label",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Testing A",
+            },
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "The label",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Testing B",
+            },
+          ],
+        },
+        "type": "entity",
+      }
+    `);
+  });
+
+  test('it can hydrate model with multiple fields', () => {
+    expect(
+      hydrateCaptureModel(simpleModel, {
+        label: ['Testing A', 'Testing B'],
+        name: 'testing',
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "My form",
+  "properties": Object {
+    "label": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "The label",
+        "selector": undefined,
+        "type": "text-field",
+        "value": "Testing A",
+      },
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "The label",
+        "selector": undefined,
+        "type": "text-field",
+        "value": "Testing B",
+      },
+    ],
+    "name": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "Name of person",
+        "selector": undefined,
+        "type": "text-field",
+        "value": "testing",
+      },
+    ],
+  },
+  "type": "entity",
+}
+`);
+  });
+
+  const complexModelWithEntity: CaptureModel['document'] = {
+    id: uuid.v4(),
+    type: 'entity',
+    label: 'My form',
+    properties: {
+      label: [
+        {
+          id: uuid.v4(),
+          label: 'The label',
+          type: 'text-field',
+          value: '',
+        },
+      ],
+      people: [
+        {
+          id: uuid.v4(),
+          label: 'Name of person',
+          type: 'entity',
+          properties: {
+            name: [
+              {
+                id: uuid.v4(),
+                label: 'First name',
+                type: 'text-field',
+                value: '',
+              },
+            ],
+            city: [
+              {
+                id: uuid.v4(),
+                label: 'City',
+                type: 'text-field',
+                value: '',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  test('it can hydrate a list of entities', () => {
+    const doc = {
+      label: 'Some label',
+      people: [
+        {
+          name: 'Stephen',
+          city: 'Glasgow',
+        },
+        {
+          name: 'Bob',
+          city: 'Edinburgh',
+        },
+      ],
+    };
+
+    expect(hydrateCaptureModel(complexModelWithEntity, doc)).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "My form",
+  "properties": Object {
+    "label": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "The label",
+        "selector": undefined,
+        "type": "text-field",
+        "value": "Some label",
+      },
+    ],
+    "people": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "Name of person",
+        "properties": Object {
+          "city": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "City",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Glasgow",
+            },
+          ],
+          "name": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "First name",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Stephen",
+            },
+          ],
+        },
+        "type": "entity",
+      },
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "Name of person",
+        "properties": Object {
+          "city": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "City",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Edinburgh",
+            },
+          ],
+          "name": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "First name",
+              "selector": undefined,
+              "type": "text-field",
+              "value": "Bob",
+            },
+          ],
+        },
+        "type": "entity",
+      },
+    ],
+  },
+  "type": "entity",
+}
+`);
+  });
+
+  test('short hand capture model', () => {
+    expect(
+      captureModelShorthand({
+        label: 'text-field',
+        name: 'text-field',
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "Root",
+  "properties": Object {
+    "label": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "label",
+        "type": "text-field",
+        "value": null,
+      },
+    ],
+    "name": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "name",
+        "type": "text-field",
+        "value": null,
+      },
+    ],
+  },
+  "type": "entity",
+}
+`);
+  });
+
+  test('nested short hand capture model', () => {
+    expect(
+      captureModelShorthand({
+        label: 'text-field',
+        'person.name': 'text-field',
+        'person.city': 'text-field',
+        'person.relation.description': 'text-field',
+        'person.relation.label': 'text-field',
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "Root",
+  "properties": Object {
+    "label": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "label",
+        "type": "text-field",
+        "value": null,
+      },
+    ],
+    "person": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "person",
+        "properties": Object {
+          "city": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "city",
+              "type": "text-field",
+              "value": null,
+            },
+          ],
+          "name": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "name",
+              "type": "text-field",
+              "value": null,
+            },
+          ],
+          "relation": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "relation",
+              "properties": Object {
+                "description": Array [
+                  Object {
+                    "id": "[--------GENERATED-ID--------]",
+                    "label": "description",
+                    "type": "text-field",
+                    "value": null,
+                  },
+                ],
+                "label": Array [
+                  Object {
+                    "id": "[--------GENERATED-ID--------]",
+                    "label": "label",
+                    "type": "text-field",
+                    "value": null,
+                  },
+                ],
+              },
+              "type": "entity",
+            },
+          ],
+        },
+        "type": "entity",
+      },
+    ],
+  },
+  "type": "entity",
+}
+`);
+  });
+
+  test('nested short hand capture model with extra options', () => {
+    expect(
+      captureModelShorthand({
+        label: 'text-field',
+        'person.name': 'text-field',
+        'person.city': {
+          type: 'dropdown',
+          options: [
+            { value: 'aberdeen', text: 'Aberdeen' },
+            { value: 'glasgow', text: 'Glasgow' },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "Root",
+  "properties": Object {
+    "label": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "label",
+        "type": "text-field",
+        "value": null,
+      },
+    ],
+    "person": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "person",
+        "properties": Object {
+          "city": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "city",
+              "options": Array [
+                Object {
+                  "text": "Aberdeen",
+                  "value": "aberdeen",
+                },
+                Object {
+                  "text": "Glasgow",
+                  "value": "glasgow",
+                },
+              ],
+              "type": "dropdown",
+              "value": null,
+            },
+          ],
+          "name": Array [
+            Object {
+              "id": "[--------GENERATED-ID--------]",
+              "label": "name",
+              "type": "text-field",
+              "value": null,
+            },
+          ],
+        },
+        "type": "entity",
+      },
+    ],
+  },
+  "type": "entity",
+}
+`);
+  });
+
+  test('hydrating compressed model', () => {
+    expect(
+      hydrateCompressedModel({
+        __meta__: {
+          title: 'text-field',
+        },
+        title: 'testing a title',
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "id": "[--------GENERATED-ID--------]",
+  "label": "Root",
+  "properties": Object {
+    "title": Array [
+      Object {
+        "id": "[--------GENERATED-ID--------]",
+        "label": "title",
+        "selector": undefined,
+        "type": "text-field",
+        "value": "testing a title",
+      },
+    ],
+  },
+  "type": "entity",
+}
+`);
+  });
+});

--- a/packages/helpers/src/__tests__/capture-model-serialisation.test.ts
+++ b/packages/helpers/src/__tests__/capture-model-serialisation.test.ts
@@ -1,0 +1,165 @@
+import { serialiseCaptureModel } from '../serialise-capture-model';
+import uuid from 'uuid';
+import { CaptureModel } from '../../../types/src/capture-model';
+
+describe('capture model serialisation', () => {
+  test('it can serialise simple models', () => {
+    expect(
+      serialiseCaptureModel({
+        id: uuid.v4(),
+        type: 'entity',
+        label: 'My form',
+        properties: {
+          label: [
+            {
+              id: uuid.v4(),
+              label: 'The label',
+              type: 'text-field',
+              value: 'Test label',
+            },
+          ],
+          name: [
+            {
+              id: uuid.v4(),
+              label: 'Name of person',
+              type: 'text-field',
+              value: 'Test name',
+            },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "label": "Test label",
+        "name": "Test name",
+      }
+    `);
+  });
+
+  test('it can serialise simple models with metadata', () => {
+    expect(
+      serialiseCaptureModel(
+        {
+          id: uuid.v4(),
+          type: 'entity',
+          label: 'My form',
+          properties: {
+            label: [
+              {
+                id: uuid.v4(),
+                label: 'The label',
+                type: 'text-field',
+                value: 'Test label',
+              },
+            ],
+            name: [
+              {
+                id: uuid.v4(),
+                label: 'Name of person',
+                type: 'text-field',
+                value: 'Test name',
+              },
+            ],
+          },
+        },
+        { addMetadata: true }
+      )
+    ).toMatchInlineSnapshot(`
+Object {
+  "__meta__": Object {
+    "label": "text-field",
+    "name": "text-field",
+  },
+  "label": "Test label",
+  "name": "Test name",
+}
+`);
+  });
+
+  test('it can serialise model with entity', () => {
+    const complexModelWithEntity: CaptureModel['document'] = {
+      id: uuid.v4(),
+      type: 'entity',
+      label: 'My form',
+      properties: {
+        label: [
+          {
+            id: uuid.v4(),
+            label: 'The label',
+            type: 'text-field',
+            value: '',
+          },
+        ],
+        people: [
+          {
+            id: uuid.v4(),
+            label: 'Name of person',
+            type: 'entity',
+            properties: {
+              name: [
+                {
+                  id: uuid.v4(),
+                  label: 'First name',
+                  type: 'text-field',
+                  value: 'First persons name',
+                },
+              ],
+              city: [
+                {
+                  id: uuid.v4(),
+                  label: 'City',
+                  type: 'text-field',
+                  value: 'Aberdeen',
+                },
+              ],
+            },
+          },
+          {
+            id: uuid.v4(),
+            label: 'Name of person',
+            type: 'entity',
+            properties: {
+              name: [
+                {
+                  id: uuid.v4(),
+                  label: 'First name',
+                  type: 'text-field',
+                  value: 'Second persons name',
+                },
+              ],
+              city: [
+                {
+                  id: uuid.v4(),
+                  label: 'City',
+                  type: 'text-field',
+                  value: 'Glasgow',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(serialiseCaptureModel(complexModelWithEntity, { addMetadata: true })).toMatchInlineSnapshot(`
+Object {
+  "__meta__": Object {
+    "label": "text-field",
+    "people.city": "text-field",
+    "people.name": "text-field",
+  },
+  "label": "",
+  "people": Array [
+    Object {
+      "city": "Aberdeen",
+      "name": "First persons name",
+    },
+    Object {
+      "city": "Glasgow",
+      "name": "Second persons name",
+    },
+  ],
+}
+`);
+  });
+});

--- a/packages/helpers/src/capture-model-shorthand.ts
+++ b/packages/helpers/src/capture-model-shorthand.ts
@@ -1,0 +1,73 @@
+import { CaptureModel } from '../../types/src/capture-model';
+import { generateId } from './generate-id';
+
+export function captureModelShorthand(shorthand: {
+  [key: string]: string | any;
+}): CaptureModel['document'] {
+  const model: CaptureModel['document'] = {
+    id: generateId(),
+    type: 'entity',
+    label: 'Root',
+    properties: {},
+  };
+
+  const metadata = shorthand;
+  const originalKeys = Object.keys(shorthand);
+
+  const processLevel = (doc: CaptureModel['document'], key: string[], originalKey: string) => {
+    if (key.length === 0) {
+      return;
+    }
+    if (key.length === 1) {
+      // Add a field.
+
+      const metadataValue = metadata[originalKey];
+      if (typeof metadataValue !== 'string' && !metadataValue.type) {
+        // If there's no type, we can't make a field.
+        return;
+      }
+
+      doc.properties[key[0]] = [
+        typeof metadataValue === 'string'
+          ? {
+              id: generateId(),
+              label: key[0], // @todo config for mapping fields to labels.
+              type: metadataValue,
+              value: null,
+            }
+          : ({
+              id: generateId(),
+              type: metadataValue.type,
+              label: key[0], // @todo config for mapping fields to labels.
+              value: null,
+              ...metadataValue,
+            } as any),
+      ];
+      return;
+    }
+
+    const templateEntity =
+      doc.properties[key[0]] && doc.properties[key[0]].length
+        ? (doc.properties[key[0]][0] as any)
+        : ({
+            id: generateId(),
+            type: 'entity',
+            label: key[0], // @todo config for mapping fields to labels
+            properties: {},
+          } as CaptureModel['document']);
+
+    // Recursion.
+    processLevel(templateEntity, key.slice(1), originalKey);
+    // Finally add the entity to the field.
+    doc.properties[key[0]] = [templateEntity];
+  };
+
+  for (let i = 0; i < originalKeys.length; i++) {
+    const originalKey = originalKeys[i];
+    const splitKey = originalKey.split('.');
+
+    processLevel(model, splitKey, originalKey);
+  }
+
+  return model;
+}

--- a/packages/helpers/src/hydrate-capture-model.ts
+++ b/packages/helpers/src/hydrate-capture-model.ts
@@ -1,0 +1,53 @@
+import { CaptureModel } from '../../types/src/capture-model';
+import { isEntity } from './is-entity';
+import { generateId } from './generate-id';
+
+export function hydrateCaptureModel<T = any>(
+  doc: CaptureModel['document'],
+  json: T,
+  config: { keepExtraFields?: boolean } = {}
+) {
+  const { keepExtraFields = false } = config;
+  const properties = Object.keys(doc.properties);
+  const newDoc: CaptureModel['document'] = {
+    ...doc,
+    id: generateId(),
+    properties: {},
+  };
+  for (const prop of properties) {
+    const jsonValue = typeof (json as any)[prop] === 'undefined' ? [] : (json as any)[prop];
+    const values = Array.isArray(jsonValue) ? jsonValue : [jsonValue];
+    const modelTemplates = doc.properties[prop];
+    const modelTemplate = modelTemplates ? modelTemplates[0] : undefined;
+
+    // Ignore properties that don't exist.
+    if (!modelTemplate) continue;
+
+    if (values.length === 0) {
+      if (keepExtraFields) {
+        newDoc.properties[prop] = {
+          ...modelTemplate,
+          id: generateId(),
+        } as any;
+      }
+      continue;
+    }
+
+    if (isEntity(modelTemplate)) {
+      newDoc.properties[prop] = values.map((value: any) => {
+        return hydrateCaptureModel(modelTemplate, value, config);
+      }) as any;
+    } else {
+      newDoc.properties[prop] = values.map((value: any) => {
+        return {
+          ...modelTemplate,
+          id: generateId(),
+          value,
+          selector: undefined, // @todo come back to selectors.
+        };
+      });
+    }
+  }
+
+  return newDoc;
+}

--- a/packages/helpers/src/hydrate-compressed-model.ts
+++ b/packages/helpers/src/hydrate-compressed-model.ts
@@ -1,0 +1,9 @@
+import { CaptureModel } from '../../types/src/capture-model';
+import { generateId } from './generate-id';
+import { BaseField } from '../../types/src/field-types';
+import { captureModelShorthand } from './capture-model-shorthand';
+import { hydrateCaptureModel } from './hydrate-capture-model';
+
+export function hydrateCompressedModel<T = any>({ __meta__, ...json }: T & { __meta__: { [key: string]: string } }) {
+  return hydrateCaptureModel(captureModelShorthand(__meta__), json);
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -33,3 +33,7 @@ export * from './split-document-by-model-root';
 export * from './traverse-document';
 export * from './traverse-structure';
 export * from './validate-revision';
+export * from './capture-model-shorthand';
+export * from './hydrate-capture-model';
+export * from './hydrate-compressed-model';
+export * from './serialise-capture-model';

--- a/packages/helpers/src/serialise-capture-model.ts
+++ b/packages/helpers/src/serialise-capture-model.ts
@@ -1,0 +1,87 @@
+import { CaptureModel } from '../../types/src/capture-model';
+import { isEntityList } from './is-entity';
+
+export function serialiseCaptureModel<T = any>(
+  model: CaptureModel['document'],
+  options: { addMetadata?: boolean } = {},
+  metadataAggregate?: { aggregate: any; key: string }
+): undefined | T {
+  const { addMetadata } = options;
+  const properties = Object.keys(model.properties);
+
+  const newDoc = {} as any;
+  const metadataAgg = metadataAggregate ? metadataAggregate.aggregate : {};
+
+  if (properties.length === 0) {
+    return undefined; // Always return undefined if there are no properties.
+  }
+
+  for (const prop of properties) {
+    const modelTemplate = model.properties[prop];
+
+    if (modelTemplate.length === 0) {
+      // This shouldn't happen with a valid model.
+      continue;
+    }
+
+    if (isEntityList(modelTemplate)) {
+      // We have an entity list.
+      if (modelTemplate.length === 1) {
+        const serialised = serialiseCaptureModel(
+          modelTemplate[0],
+          options,
+          addMetadata
+            ? {
+                aggregate: metadataAgg,
+                key: metadataAggregate ? `${metadataAggregate.key}.${prop}` : prop,
+              }
+            : undefined
+        );
+        if (typeof serialised !== 'undefined') {
+          newDoc[prop] = serialised;
+        }
+        continue;
+      }
+      newDoc[prop] = modelTemplate
+        .map(template =>
+          serialiseCaptureModel(
+            template,
+            options,
+            addMetadata
+              ? {
+                  aggregate: metadataAgg,
+                  key: metadataAggregate ? `${metadataAggregate.key}.${prop}` : prop,
+                }
+              : undefined
+          )
+        )
+        // Filter any undefined documents.
+        .filter(doc => typeof doc !== 'undefined');
+    } else {
+      if (addMetadata) {
+        metadataAgg[metadataAggregate && metadataAggregate.key ? `${metadataAggregate.key}.${prop}` : prop] =
+          modelTemplate[0].type;
+      }
+      // When its a single field.
+      if (modelTemplate.length === 1) {
+        const value = modelTemplate[0].value;
+        // Null indicates that no user has edited it as a default from the model.
+        if (value !== null && typeof value !== 'undefined') {
+          newDoc[prop] = value;
+        }
+        continue;
+      }
+      newDoc[prop] = modelTemplate
+        .map(template => {
+          return template.value;
+        })
+        .filter(value => value !== null && typeof value !== 'undefined');
+    }
+  }
+
+  if (addMetadata && !metadataAggregate) {
+    newDoc.__meta__ = metadataAgg;
+  }
+
+  return newDoc;
+}


### PR DESCRIPTION
Few new capture model helpers that will trickle down to Madoc shortly. All of the utilities make it easier to write logical capture models in code that can be used to provide the capture model interface for non-crowdsourcing requirements - for example with content management UIs. 

The idea is that you can hard-code the capture model in the code to produce predictable JSON and then convert that predictable JSON back to capture model, edit it and then re-serialise it on the fly. This way you are only storing the output JSON and not the verbose intermediate format. 

Some examples of the utilities are below. Specification will likely change to cover more complex models with custom options etc. The short-hand is mostly complete, as you can opt-out of the short hand and start using the full model properties, but the serialisation does not yet produce these "slightly-less-short" variations.

### Capture model short hand
```javascript
const shortHand = {
  label: 'text-field',
  'person.name': 'text-field',
  'person.city': {
    type: 'dropdown',
    options: [
      { value: 'aberdeen', text: 'Aberdeen' },
      { value: 'glasgow', text: 'Glasgow' },
    ],
  },
})
```

<details>
<summary>
Click to reveal generated capture model
</summary>

```
Object {
  "id": "[--------GENERATED-ID--------]",
  "label": "Root",
  "properties": Object {
    "label": Array [
      Object {
        "id": "[--------GENERATED-ID--------]",
        "label": "label",
        "type": "text-field",
        "value": null,
      },
    ],
    "person": Array [
      Object {
        "id": "[--------GENERATED-ID--------]",
        "label": "person",
        "properties": Object {
          "city": Array [
            Object {
              "id": "[--------GENERATED-ID--------]",
              "label": "city",
              "options": Array [
                Object {
                  "text": "Aberdeen",
                  "value": "aberdeen",
                },
                Object {
                  "text": "Glasgow",
                  "value": "glasgow",
                },
              ],
              "type": "dropdown",
              "value": null,
            },
          ],
          "name": Array [
            Object {
              "id": "[--------GENERATED-ID--------]",
              "label": "name",
              "type": "text-field",
              "value": null,
            },
          ],
        },
        "type": "entity",
      },
    ],
  },
  "type": "entity",
}
```

</details>

### Capture model serialisation
```js
const exampleModel = {
  id: "[--------GENERATED-ID--------]",
  type: 'entity',
  label: 'My form',
  properties: {
    label: [
      {
        id: "[--------GENERATED-ID--------]",
        label: 'The label',
        type: 'text-field',
        value: 'Test label',
      },
    ],
    name: [
      {
        id: "[--------GENERATED-ID--------]",
        label: 'Name of person',
        type: 'text-field',
        value: 'Test name',
      },
    ],
  },
}
```

will produce the following JSON:
```json
{
    "label": "Test label",
    "name": "Test name",
}
```

If you pass the option "withMetadata", then it will produce a short hand (like above) and works with nested entities.
```
{
    "__meta__": {
        "label": "text-field",
        "name": "text-field"
    },
    "label": "Test label",
    "name": "Test name",
}
```

### Capture model hydration

The opposite of the above. If you provide the following model (note the empty fields):

<details>
<summary>Click to see full model</summary>

```js
const exampleModel = {
  id: "[--------GENERATED-ID--------]",
  type: 'entity',
  label: 'My form',
  properties: {
    label: [
      {
        id: "[--------GENERATED-ID--------]",
        label: 'The label',
        type: 'text-field',
        value: '',
      },
    ],
    name: [
      {
        id: "[--------GENERATED-ID--------]",
        label: 'Name of person',
        type: 'text-field',
        value: '',
      },
    ],
  },
}
```

</details>

and the following JSON:
```json
{
    "label": ["Test label 1", "Test label 2"],
    "name": "Test name",
}
```

Then it will populate the capture model with all of the values from the JSON. Limitation: values of the fields must be literals at the moment (strings, numbers). Can build on this as we need to.

### Hydrating shorthand
If you provide the following example from above:
```json
{
    "__meta__": {
        "label": "text-field",
        "name": "text-field"
    },
    "label": "Test label",
    "name": "Test name",
}
```

Then it will use the meta to create a capture model (first item) and then hydrate that model.


**All of these utilities are intended to be used for temporary capture models in code**

### Target React API:

```jsx

function MyGreatForm(props) {
   const [editor, json] = useInlineModel({
       'metadata.label': 'text-field',
       'metadata.value': 'text-field',
   }, props.initialValue);

   return (
    <div>
      {editor}
      <button onClick={() => props.onSave(json)}>Save changes</button>
    </div>
  );
}

```