### PR TITLE
Capture models deleted when approving

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       - shared-postgres
     volumes:
       - ./packages/server/lib:/home/node/app/lib:delegated
+      - ./packages/database/lib:/home/node/app/node_modules/@capture-models/database/lib:delegated
     ports:
       - 3000:3000
 

--- a/e2e/cypress/integration/bugs/01-approve-revision.ts
+++ b/e2e/cypress/integration/bugs/01-approve-revision.ts
@@ -1,0 +1,93 @@
+import { BaseField, CaptureModel, RevisionRequest } from '@capture-models/types';
+
+it('Should keep properties when approving a revision', () => {
+  const revisionRequest = {
+    captureModelId: '5b49767b-f79b-4039-b933-9c917498dc42',
+    revision: {
+      structureId: '9c2c6558-703d-4276-ac44-01c78e66ecef',
+      label: 'Default',
+      id: '7b0052c9-ff2c-4463-b198-c6bcc6d18606',
+      fields: ['regionOfInterest'],
+      status: 'accepted',
+      revises: null,
+      authors: ['urn:madoc:user:1'],
+    },
+    document: {
+      id: '4f6d0447-b3fa-4ed9-b137-7f6e68f4849c',
+      type: 'entity',
+      label: 'Untitled document',
+      properties: {
+        regionOfInterest: [
+          {
+            id: '3930eefd-50bf-40f1-9ed6-f7c59aea693c',
+            type: 'text-field',
+            label: 'regionOfInterest',
+            value: 'tests with a change',
+            revises: '48304e90-4257-4cbd-b3ef-4c8fcfb45b96',
+            selector: { id: '01a9a2fd-bb23-4cfa-b3b4-7be643c66a15', type: 'box-selector', state: null },
+            revision: '7b0052c9-ff2c-4463-b198-c6bcc6d18606',
+          },
+        ],
+      },
+    },
+    source: 'structure',
+    status: 'accepted',
+  };
+
+  cy.loadFixture('97-bugs/01-approve-revision');
+
+  cy.apiRequest<RevisionRequest>({
+    url: `/api/crowdsourcing/revision/${revisionRequest.revision.id}`,
+    method: 'PUT',
+    body: revisionRequest,
+  }).then(res => {
+    expect(res.body.document.properties.regionOfInterest).not.to.be.undefined;
+    expect((res.body.document.properties.regionOfInterest[0] as BaseField).value).to.equal('tests with a change');
+    expect(res.body.revision).to.deep.equal({
+      structureId: '9c2c6558-703d-4276-ac44-01c78e66ecef',
+      approved: true,
+      label: 'Default',
+      id: '7b0052c9-ff2c-4463-b198-c6bcc6d18606',
+      fields: ['regionOfInterest'],
+      status: 'accepted',
+      revises: null,
+      authors: ['urn:madoc:user:1'],
+    });
+  });
+
+  cy.apiRequest<CaptureModel>(`/api/crowdsourcing/model/${revisionRequest.captureModelId}`).then(res => {
+    const model = res.body;
+
+    expect(model.document).to.deep.equal({
+      id: '4f6d0447-b3fa-4ed9-b137-7f6e68f4849c',
+      type: 'entity',
+      label: 'Untitled document',
+      properties: {
+        regionOfInterest: [
+          // The original field is retained.
+          {
+            id: '48304e90-4257-4cbd-b3ef-4c8fcfb45b96',
+            type: 'text-field',
+            label: 'regionOfInterest',
+            value: '',
+            selector: { id: '6353eac6-518d-4a28-a598-b251f754db9c', type: 'box-selector', state: null },
+          },
+
+          // The new field is also available, with it's revises.
+          {
+            id: '3930eefd-50bf-40f1-9ed6-f7c59aea693c',
+            type: 'text-field',
+            label: 'regionOfInterest',
+            value: 'tests with a change',
+            // Here it will replace the other field that's visible.
+            // @todo what happens when 2 fields revise the same field? This is a situation where there is a conflict
+            //       that needs to be fixed in the model.
+            revises: '48304e90-4257-4cbd-b3ef-4c8fcfb45b96',
+            selector: { id: '01a9a2fd-bb23-4cfa-b3b4-7be643c66a15', type: 'box-selector', state: null },
+            revision: '7b0052c9-ff2c-4463-b198-c6bcc6d18606',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -41,8 +41,10 @@ Cypress.Commands.add('apiRequest', (request, scope, cb) => {
       expiresIn: 24 * 60 * 60 * 365,
     })
     .then(token => {
+      const requestData = typeof request === 'string' ? { url: request, method: 'get' } : request;
+
       return cy.request({
-        ...request,
+        ...requestData,
         auth: {
           bearer: token,
         },

--- a/e2e/cypress/support/index.d.ts
+++ b/e2e/cypress/support/index.d.ts
@@ -8,7 +8,7 @@ declare namespace Cypress {
   // eslint-disable-next-line @typescript-eslint/class-name-casing
   interface cy {
     loadFixture(fixtureName: string): { then: (res: (model: { body: CaptureModel }) => void) => any };
-    apiRequest<Return>(request: RequestBody): { then: (res: (model: { body: Return }) => void) => any };
+    apiRequest<Return>(request: RequestBody | string): { then: (res: (model: { body: Return }) => void) => any };
   }
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface Chainable {

--- a/fixtures/97-bugs/01-approve-revision.json
+++ b/fixtures/97-bugs/01-approve-revision.json
@@ -1,0 +1,89 @@
+{
+  "id": "5b49767b-f79b-4039-b933-9c917498dc42",
+  "structure": {
+    "id": "16e4789c-6866-4271-bdfd-ee5220e9ffeb",
+    "type": "choice",
+    "label": "First project",
+    "items": [
+      {
+        "id": "9c2c6558-703d-4276-ac44-01c78e66ecef",
+        "type": "model",
+        "label": "Default",
+        "fields": [
+          "regionOfInterest"
+        ]
+      }
+    ]
+  },
+  "document": {
+    "id": "4f6d0447-b3fa-4ed9-b137-7f6e68f4849c",
+    "type": "entity",
+    "label": "Untitled document",
+    "properties": {
+      "regionOfInterest": [
+        {
+          "id": "48304e90-4257-4cbd-b3ef-4c8fcfb45b96",
+          "type": "text-field",
+          "label": "regionOfInterest",
+          "value": "",
+          "selector": {
+            "id": "6353eac6-518d-4a28-a598-b251f754db9c",
+            "type": "box-selector",
+            "state": null
+          }
+        },
+        {
+          "id": "3930eefd-50bf-40f1-9ed6-f7c59aea693c",
+          "type": "text-field",
+          "label": "regionOfInterest",
+          "value": "tests",
+          "revises": "48304e90-4257-4cbd-b3ef-4c8fcfb45b96",
+          "selector": {
+            "id": "01a9a2fd-bb23-4cfa-b3b4-7be643c66a15",
+            "type": "box-selector",
+            "state": null
+          },
+          "revision": "7b0052c9-ff2c-4463-b198-c6bcc6d18606"
+        }
+      ]
+    }
+  },
+  "target": [
+    {
+      "id": "urn:madoc:collection:1",
+      "type": "Collection"
+    },
+    {
+      "id": "urn:madoc:manifest:3",
+      "type": "Manifest"
+    },
+    {
+      "id": "urn:madoc:canvas:46",
+      "type": "Canvas"
+    }
+  ],
+  "profile": null,
+  "revisions": [
+    {
+      "structureId": "9c2c6558-703d-4276-ac44-01c78e66ecef",
+      "approved": false,
+      "label": "Default",
+      "id": "7b0052c9-ff2c-4463-b198-c6bcc6d18606",
+      "fields": [
+        "regionOfInterest"
+      ],
+      "status": "submitted",
+      "revises": null,
+      "authors": [
+        "urn:madoc:user:1"
+      ]
+    }
+  ],
+  "contributors": {
+    "urn:madoc:user:1": {
+      "id": "urn:madoc:user:1",
+      "type": "Person",
+      "name": "admin"
+    }
+  }
+}

--- a/packages/database/src/repository.ts
+++ b/packages/database/src/repository.ts
@@ -760,18 +760,22 @@ export class CaptureModelRepository {
     // Extract old document values.
     traverseDocument(storedRevision.document, {
       visitField(field) {
-        fieldIds.push(field.id);
-        fieldMap[field.id] = field;
-        if (field.selector) {
-          selectorIds.push(field.selector.id);
-          selectorMap[field.selector.id] = field.selector;
+        if (field.revision && field.revision === req.revision.id) {
+          fieldIds.push(field.id);
+          fieldMap[field.id] = field;
+          if (field.selector) {
+            selectorIds.push(field.selector.id);
+            selectorMap[field.selector.id] = field.selector;
+          }
         }
       },
       visitEntity(entity) {
-        entityIds.push(entity.id);
-        if (entity.selector) {
-          selectorIds.push(entity.selector.id);
-          selectorMap[entity.selector.id] = entity.selector.state;
+        if (entity.revision && entity.revision === req.revision.id) {
+          entityIds.push(entity.id);
+          if (entity.selector) {
+            selectorIds.push(entity.selector.id);
+            selectorMap[entity.selector.id] = entity.selector.state;
+          }
         }
       },
     });


### PR DESCRIPTION
When you update a revision the service expects you to include new or changed fields, but also the original fields that these replace. If the original fields were omitted (in Madoc these are omitted when approving a revision) it would be detected as a removal of that field. The original field would then be deleted. 

This change will remove any canonical resources from the comparison when deciding which to add, change and remove.